### PR TITLE
Null field error

### DIFF
--- a/model.php
+++ b/model.php
@@ -389,7 +389,7 @@ class Model extends \JTable
         ob_start();
         $field_processer = '_renderListControl'.$field;
         if(method_exists($this,$field_processer)){
-            $this->$field_processer();
+            $this->$field_processer($field);
         }else{
             switch ($defenition['type']){
                 case 'user':


### PR DESCRIPTION
Warning: Missing argument 1 for Joomplace\Library\JooYii\Model::_renderListControlText(), called in C:\OpenServer\domains\jlms.lem\libraries\JooYii\model.php on line 394 and defined in C:\OpenServer\domains\jlms.lem\libraries\JooYii\model.php on line 439

Fatal error: Cannot access empty property in C:\OpenServer\domains\jlms.lem\libraries\JooYii\model.php on line 441
